### PR TITLE
fix: improve i18n detection and disable example selection until v4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "minimist": "^1.2.6",
         "npm-check-updates": "^11.8.5",
         "ora": "^5.4.1",
-        "os-locale": "^5.0.0",
         "tar": "^6.2.0"
     }
 }

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,9 +1,28 @@
-import osLocale from "os-locale";
 import { i18nEnUs } from "./en-us";
 import { i18nZhCn } from "./zh-cn";
 
+/**
+ * Detect system locale from environment variables
+ * Priority: LC_ALL > LC_MESSAGES > LANG
+ * Returns locale string or empty string if not detected
+ */
+function getSystemLocale(): string {
+    const locale = process.env.LC_ALL
+        || process.env.LC_MESSAGES
+        || process.env.LANG
+        || '';
+    return locale.toLowerCase();
+}
+
+/**
+ * Check if system locale is Chinese
+ * Matches: zh_cn, zh-cn, zh_tw, zh-tw, zh.utf-8, etc.
+ */
+function isChineseLocale(): boolean {
+    const locale = getSystemLocale();
+    return locale.startsWith('zh_') || locale.startsWith('zh-') || locale.startsWith('zh.');
+}
+
 // 根据系统语言判断中英文
-export const isZhCN = osLocale.sync() === 'zh-CN'
-export const i18n = isZhCN ? i18nZhCn : i18nEnUs
-// TODO en-us
-// export const i18n = i18nEnUs;
+export const isZhCN = isChineseLocale();
+export const i18n = isZhCN ? i18nZhCn : i18nEnUs;

--- a/src/models/inputCreateOptions.ts
+++ b/src/models/inputCreateOptions.ts
@@ -59,22 +59,23 @@ export async function inputCreateOptions(options: InputCreateOptionsExt): Promis
         }
     }
 
+    // TODO: Enable example selection in v4.0
     // Check if user wants to start from example
     // --from-example: force show example selection
     // --no-example: skip example selection
     // default: show example selection only when no preset is used
-    const shouldShowExampleSelection = options.fromExample ||
-        (!options.noExample && !options.client && !options.server);
-
-    if (shouldShowExampleSelection) {
-        const selectedExample = await selectExampleOrScratch(projectDir, options.fromExample);
-        if (selectedExample) {
-            // User selected an example, create from it and exit
-            // This will throw if failed
-            return selectedExample as any; // Return special marker
-        }
-        // User chose "from scratch", continue with normal flow
-    }
+    // const shouldShowExampleSelection = options.fromExample ||
+    //     (!options.noExample && !options.client && !options.server);
+    //
+    // if (shouldShowExampleSelection) {
+    //     const selectedExample = await selectExampleOrScratch(projectDir, options.fromExample);
+    //     if (selectedExample) {
+    //         // User selected an example, create from it and exit
+    //         // This will throw if failed
+    //         return selectedExample as any; // Return special marker
+    //     }
+    //     // User chose "from scratch", continue with normal flow
+    // }
 
     // client
     // 请选择要创建的项目类型


### PR DESCRIPTION
- Replace unstable os-locale library with direct env var detection (LC_ALL > LC_MESSAGES > LANG)
- Improve Chinese locale matching (zh_*, zh-*, zh.*)
- Temporarily disable example selection in interactive mode until v4.0 (--example and --list-examples flags still work)