### PR TITLE
enhance i18n support

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "minimist": "^1.2.6",
         "npm-check-updates": "^11.8.5",
         "ora": "^5.4.1",
+        "os-locale-s": "^1.0.26",
         "tar": "^6.2.0"
     }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ export default {
             rollupCommonJSResolveHack: true
         }),
         replace({
-            '__PACKAGE_JSON_VERSION__': require('./package.json').version,
+            '__CTA_VERSION__': require('./package.json').version,
             'process.env.NODE_ENV': '"production"'
         }),
         terser({

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,26 +1,48 @@
+import { execSync } from "child_process";
+import { osLocale } from "os-locale-s";
 import { i18nEnUs } from "./en-us";
 import { i18nZhCn } from "./zh-cn";
 
 /**
- * Detect system locale from environment variables
- * Priority: LC_ALL > LC_MESSAGES > LANG
- * Returns locale string or empty string if not detected
+ * Check if a locale string indicates Chinese
+ * Matches: zh_cn, zh-cn, zh_tw, zh-tw, zh-hans, zh-hant, etc.
  */
-function getSystemLocale(): string {
-    const locale = process.env.LC_ALL
-        || process.env.LC_MESSAGES
-        || process.env.LANG
-        || '';
-    return locale.toLowerCase();
+function matchesChinese(locale: string): boolean {
+    return /^zh[-_.]/.test(locale) || /^zh$/.test(locale);
 }
 
 /**
- * Check if system locale is Chinese
- * Matches: zh_cn, zh-cn, zh_tw, zh-tw, zh.utf-8, etc.
+ * On macOS, LANG env var is often auto-set (e.g. en_AU.UTF-8)
+ * and doesn't reflect the actual system language preference.
+ * Use `defaults read -g AppleLocale` as fallback.
+ */
+function getMacOSLocale(): string {
+    if (process.platform !== 'darwin') return '';
+    try {
+        return execSync('defaults read -g AppleLocale', {
+            encoding: 'utf-8',
+            timeout: 3000,
+        }).trim().toLowerCase();
+    } catch {
+        return '';
+    }
+}
+
+/**
+ * Detect if system locale is Chinese
+ * 1. Use os-locale-s for cross-platform detection (env vars / wmic / defaults)
+ * 2. Fallback to macOS AppleLocale when env vars don't reflect actual preference
  */
 function isChineseLocale(): boolean {
-    const locale = getSystemLocale();
-    return locale.startsWith('zh_') || locale.startsWith('zh-') || locale.startsWith('zh.');
+    // os-locale-s: handles Windows (wmic), Linux/macOS (env vars) uniformly
+    const locale = osLocale.sync().toLowerCase();
+    if (matchesChinese(locale)) return true;
+
+    // macOS fallback: LANG often doesn't match system language
+    const macLocale = getMacOSLocale();
+    if (macLocale && matchesChinese(macLocale)) return true;
+
+    return false;
 }
 
 // 根据系统语言判断中英文

--- a/src/models/CreateOptions.ts
+++ b/src/models/CreateOptions.ts
@@ -4,7 +4,7 @@ export interface CreateOptions {
     projectDir: string
     server: 'http' | 'ws'
     client: ClientPlatform
-    features: (ServerFeature | ClientFeature)[]
+    features: (ServerFeature | ClientFeature | CommonFeature)[]
     aiEditors?: AIEditor[]  // Selected AI editors when ai-friendly is enabled
 }
 
@@ -13,6 +13,16 @@ export type ClientPlatform = 'browser' | 'react' | 'vue3' | 'none' | 'node'
 export type ServerFeature = 'unitTest'
 
 export type ClientFeature = 'symlink' | 'tailwind' | 'ai-friendly'
+
+export type CommonFeature = 'eslint'
+
+export const commonFeatures: {
+    name: string
+    value: CommonFeature
+    checked?: boolean
+}[] = [
+        { name: 'ESLint', value: 'eslint', checked: true },
+    ]
 
 export const serverFeatures: {
     name: string

--- a/src/models/createApp.ts
+++ b/src/models/createApp.ts
@@ -157,8 +157,23 @@ async function createServer(options: CreateOptions, registry: string | undefined
         delete packageJson.scripts['test:watch'];
         delete packageJson.devDependencies.vitest;
     }
+    // ESLint
+    if (options.features.indexOf('eslint') > -1) {
+        packageJson.devDependencies = packageJson.devDependencies || {};
+        packageJson.devDependencies['eslint'] = '^9.0.0';
+        packageJson.devDependencies['@eslint/js'] = '^9.0.0';
+        packageJson.devDependencies['typescript-eslint'] = '^8.0.0';
+        packageJson.devDependencies['globals'] = '^15.0.0';
+        packageJson.scripts = packageJson.scripts || {};
+        packageJson.scripts['lint'] = 'eslint src/';
+    }
     await fs.writeFile(path.join(serverDir, 'package.json'), JSON.stringify(packageJson, null, 2), 'utf-8');
     done();
+
+    // ESLint 配置文件
+    if (options.features.indexOf('eslint') > -1) {
+        await setupESLint(serverDir, 'server');
+    }
 
     // 安装依赖
     doing(`npm-check-update`)
@@ -214,20 +229,43 @@ async function createBrowserClient(options: CreateOptions, registry: string | un
     doing(i18n.genPackageJson(clientDirName))
     let packageJson = JSON.parse(await fs.readFile(path.join(clientDir, 'package.json'), 'utf-8'));
     packageJson.name = `${appName}-${clientDirName}`;
-    
+
     // Tailwind CSS v4
     if (useTailwind) {
         packageJson.devDependencies = packageJson.devDependencies || {};
         packageJson.devDependencies['tailwindcss'] = '^4.0.0';
         packageJson.devDependencies['@tailwindcss/vite'] = '^4.0.0';
     }
-    
+
+    // ESLint
+    const useESLint = options.features.indexOf('eslint') > -1;
+    if (useESLint) {
+        packageJson.devDependencies = packageJson.devDependencies || {};
+        packageJson.devDependencies['eslint'] = '^9.0.0';
+        packageJson.devDependencies['@eslint/js'] = '^9.0.0';
+        packageJson.devDependencies['typescript-eslint'] = '^8.0.0';
+        packageJson.devDependencies['globals'] = '^15.0.0';
+        if (options.client === 'react') {
+            packageJson.devDependencies['eslint-plugin-react-hooks'] = '^5.0.0';
+            packageJson.devDependencies['eslint-plugin-react-refresh'] = '^0.4.0';
+        } else if (options.client === 'vue3') {
+            packageJson.devDependencies['eslint-plugin-vue'] = '^9.0.0';
+        }
+        packageJson.scripts = packageJson.scripts || {};
+        packageJson.scripts['lint'] = 'eslint src/';
+    }
+
     await fs.writeFile(path.join(clientDir, 'package.json'), JSON.stringify(packageJson, null, 2), 'utf-8');
     done();
 
     // Tailwind 配置文件
     if (useTailwind) {
         await setupTailwind(clientDir);
+    }
+
+    // ESLint 配置文件
+    if (useESLint) {
+        await setupESLint(clientDir, options.client as 'browser' | 'react' | 'vue3');
     }
 
     // 安装依赖
@@ -287,6 +325,116 @@ async function setupTailwind(clientDir: string) {
 `;
         cssContent = tailwindImport + cssContent;
         await fs.writeFile(cssPath, cssContent, 'utf-8');
+    }
+}
+
+async function setupESLint(targetDir: string, platform: 'server' | 'browser' | 'react' | 'vue3') {
+    const configPath = path.join(targetDir, 'eslint.config.mjs');
+    let config: string;
+
+    switch (platform) {
+        case 'server':
+            config = `import globals from "globals";
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+    { ignores: ["dist/"] },
+    eslint.configs.recommended,
+    ...tseslint.configs.recommended,
+    {
+        languageOptions: {
+            globals: globals.node,
+        },
+        rules: {
+            "@typescript-eslint/no-empty-object-type": "off",
+        },
+    },
+);
+`;
+            break;
+        case 'react':
+            config = `import globals from "globals";
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+
+export default tseslint.config(
+    { ignores: ["dist/"] },
+    eslint.configs.recommended,
+    ...tseslint.configs.recommended,
+    {
+        plugins: {
+            "react-hooks": reactHooks,
+            "react-refresh": reactRefresh,
+        },
+        languageOptions: {
+            globals: globals.browser,
+        },
+        rules: {
+            ...reactHooks.configs.recommended.rules,
+            "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+        },
+    },
+);
+`;
+            break;
+        case 'vue3':
+            config = `import globals from "globals";
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+import pluginVue from "eslint-plugin-vue";
+
+export default tseslint.config(
+    { ignores: ["dist/"] },
+    eslint.configs.recommended,
+    ...tseslint.configs.recommended,
+    ...pluginVue.configs["flat/essential"],
+    {
+        languageOptions: {
+            globals: globals.browser,
+        },
+    },
+    {
+        files: ["**/*.vue"],
+        languageOptions: {
+            parserOptions: {
+                parser: tseslint.parser,
+            },
+        },
+    },
+);
+`;
+            break;
+        default:
+            config = `import globals from "globals";
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+    { ignores: ["dist/"] },
+    eslint.configs.recommended,
+    ...tseslint.configs.recommended,
+    {
+        languageOptions: {
+            globals: globals.browser,
+        },
+    },
+);
+`;
+            break;
+    }
+
+    await fs.writeFile(configPath, config, 'utf-8');
+
+    // 更新 .vscode/settings.json 添加 eslint.useFlatConfig
+    const vscodeDir = path.join(targetDir, '.vscode');
+    const settingsPath = path.join(vscodeDir, 'settings.json');
+    if (await fs.pathExists(settingsPath)) {
+        const settings = JSON.parse(await fs.readFile(settingsPath, 'utf-8'));
+        settings['eslint.useFlatConfig'] = true;
+        await fs.writeFile(settingsPath, JSON.stringify(settings, null, 4), 'utf-8');
     }
 }
 

--- a/src/models/inputCreateOptions.ts
+++ b/src/models/inputCreateOptions.ts
@@ -7,7 +7,7 @@ import { getAllExamples } from "../example/ExampleRegistry";
 import { parseExampleArg } from "../example/ExampleResolver";
 import { LocalizedString, RegistryExample, CommunityExample } from "../example/ExampleOptions";
 import { i18n, isZhCN } from "../i18n/i18n";
-import { AIEditor, clientFeatures, CreateOptions, serverFeatures } from "./CreateOptions";
+import { AIEditor, clientFeatures, commonFeatures, CreateOptions, serverFeatures } from "./CreateOptions";
 import { VERSION } from "./version";
 
 /**
@@ -98,7 +98,7 @@ export async function inputCreateOptions(options: InputCreateOptionsExt): Promis
     // features
     let features: CreateOptions['features'] = options.features || [];
     let platformClientFeatures = clientFeatures.filter(v => v.platforms.indexOf(client) > -1);
-    let featureChoices = [...serverFeatures, ...platformClientFeatures];
+    let featureChoices = [...commonFeatures, ...serverFeatures, ...platformClientFeatures];
     
     if (featureChoices.length) {
         features = (await inquirer.prompt([{

--- a/src/models/preset.ts
+++ b/src/models/preset.ts
@@ -4,44 +4,44 @@ export const preset: { [key: string]: Omit<CreateOptions, 'projectDir'> } = {
     server: {
         server: 'http',
         client: 'none',
-        features: []
+        features: ['eslint']
     },
     browser: {
         server: 'http',
         client: 'browser',
-        features: ['tailwind', 'ai-friendly'],
+        features: ['eslint', 'tailwind', 'ai-friendly'],
         aiEditors: ['claude']
     },
     react: {
         server: 'http',
         client: 'react',
-        features: ['tailwind', 'ai-friendly'],
+        features: ['eslint', 'tailwind', 'ai-friendly'],
         aiEditors: ['claude']
     },
     vue3: {
         server: 'http',
         client: 'vue3',
-        features: ['tailwind', 'ai-friendly'],
+        features: ['eslint', 'tailwind', 'ai-friendly'],
         aiEditors: ['claude']
     },
     'server-ws': {
         server: 'ws',
         client: 'none',
-        features: []
+        features: ['eslint']
     },
     'browser-ws': {
         server: 'ws',
         client: 'browser',
-        features: ['tailwind']
+        features: ['eslint', 'tailwind']
     },
     'react-ws': {
         server: 'ws',
         client: 'react',
-        features: ['tailwind']
+        features: ['eslint', 'tailwind']
     },
     'vue3-ws': {
         server: 'ws',
         client: 'vue3',
-        features: ['tailwind']
+        features: ['eslint', 'tailwind']
     },
 }

--- a/templates/server/src-http/api/ApiAddData.ts
+++ b/templates/server/src-http/api/ApiAddData.ts
@@ -12,7 +12,7 @@ export default async function (call: ApiCall<ReqAddData, ResAddData>) {
         return;
     }
 
-    let time = new Date();
+    const time = new Date();
     AllData.unshift({
         content: call.req.content,
         time: time


### PR DESCRIPTION
- 在macOS上引入额外配置用于读取用户语言设置，而不只是Shell环境变量来确定是否显示中文。
- 新增了一个ESLint的配置，可以选择是否启用

<img width="399" height="100" alt="image" src="https://github.com/user-attachments/assets/f1ad6331-18e4-43c7-9867-6cd137ba9f4c" />
